### PR TITLE
fixed preinstall version check

### DIFF
--- a/preinstall.js
+++ b/preinstall.js
@@ -1,3 +1,4 @@
+const MINIMUM_SUPPORTED_VERSION = 1.13;
 var exec = require ('child_process') .exec;
 
 var bin = process.env.NODE_APP_BIN || 'vnstat';
@@ -7,8 +8,8 @@ exec (bin + ' --version', function (err, res) {
     throw err;
   }
 
-  res.replace (/^vnStat (\d+)\.(\d+) /, function (s, major, minor) {
-    if (major >= 1 && minor >= 13) {
+  res.replace (/vnStat\ (\d+\.\d+)/, function (s, version) {
+    if (version >= MINIMUM_SUPPORTED_VERSION) {
       return;
     }
 


### PR DESCRIPTION
Fixes bug which not let install lib when vnstat version is `>1`.
For example,used with `vnstat 2.4` and version check did not pass because of minor version was lower than minimum required .13.